### PR TITLE
Fix CI Pipeline to Wait for Container Readiness before Version Check

### DIFF
--- a/.github/workflows/hivebox-test.yml
+++ b/.github/workflows/hivebox-test.yml
@@ -79,8 +79,8 @@ jobs:
             TIMEOUT=300
             TIME_ELAPSED=0
 
-            until curl -s http://localhost:8080/versionl; do
-              if [ $T"IME_ELAPSED -ge $TIMEOUT ]; then
+            until curl -s http://localhost:8080/version; do
+              if [ $TIME_ELAPSED -ge $TIMEOUT ]; then
                 echo "[ERROR] Timeout reached after $TIMEOUT seconds, stopping the pipeline..."
                 exit 1
               fi
@@ -91,4 +91,4 @@ jobs:
 
             done
 
-            echo "[OK] /version test has been completed succesfully"
+            echo "[OK] /version test has been completed successfully"

--- a/.github/workflows/hivebox-test.yml
+++ b/.github/workflows/hivebox-test.yml
@@ -5,7 +5,7 @@ on:
         - 'release/*'
         - 'testing/*'
         - 'feature/*'
-        - 'dev/'
+        - 'dev'
         - main
       paths-ignore:
         - README.md

--- a/.github/workflows/hivebox-test.yml
+++ b/.github/workflows/hivebox-test.yml
@@ -10,6 +10,12 @@ on:
       paths-ignore:
         - README.md
 
+    pull_request:
+      branches:
+        - 'main'
+      paths-ignore:
+        - README.md
+
 jobs:
     lint:
         runs-on: ubuntu-latest

--- a/.github/workflows/hivebox-test.yml
+++ b/.github/workflows/hivebox-test.yml
@@ -5,6 +5,7 @@ on:
         - 'release/*'
         - 'testing/*'
         - 'feature/*'
+        - 'dev'
         
     pull_request:
       types:

--- a/.github/workflows/hivebox-test.yml
+++ b/.github/workflows/hivebox-test.yml
@@ -75,5 +75,20 @@ jobs:
         - name: Test /version endpoint
           run: |
             docker run -d -p 8080:8080 hivebox:latest
-            sleep 5
-            curl http://localhost:8080/version
+
+            TIMEOUT=300
+            TIME_ELAPSED=0
+
+            until curl -s http://localhost:8080/versionl; do
+              if [ $T"IME_ELAPSED -ge $TIMEOUT ]; then
+                echo "[ERROR] Timeout reached after $TIMEOUT seconds, stopping the pipeline..."
+                exit 1
+              fi
+
+              echo "[INFO] Waiting for hivebox container..."
+              sleep 5
+              TIME_ELAPSED=$((TIME_ELAPSED + 5))
+
+            done
+
+            echo "[OK] /version test has been completed succesfully"

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
-// version 0.1.2
-// adding a comment8
+// test comment 1
 
 import (
     "fmt"


### PR DESCRIPTION
This change improves the Continuous Integration (CI) pipeline by adding a waiting loop and timeout mechanism to ensure that the HiveBox container is fully up and running before attempting to query the /version endpoint. Previously, tests could be executed before the container was ready, leading to unreliable results.

Key updates:
- Added a timeout loop in the "Test /version endpoint" step to check container readiness.
- Integrated fail-safe to prevent premature queries when the container is not ready.

This update ensures more stable and predictable CI/CD workflows by checking the state of the container prior to tests.
